### PR TITLE
Updating the formatting check runner to use mggj.sln

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,7 +36,7 @@ jobs:
           changed_files=$(git diff --name-only --diff-filter=ACMRT HEAD^ | grep '\.cs$' || true)
           if [ -n "$changed_files" ]; then
             echo "Checking changed files: $changed_files"
-            dotnet format --include $changed_files --verify-no-changes --verbosity detailed
+            dotnet format mggj.sln --include $changed_files --verify-no-changes --verbosity detailed
           else
             echo "No C# files changed - skipping formatting check"
           fi


### PR DESCRIPTION
This is a test fix to hopefully fix the issue Thomas is having. I updated the formatting check runner to use mggj.sln.

The error Thomas was getting was related to the formatting check: 

```
Unhandled exception: System.IO.FileNotFoundException: Both a MSBuild project file and solution file found in '/home/runner/work/mggj/mggj/'. Specify which to use with the <workspace> argument.
   at Microsoft.CodeAnalysis.Tools.Workspaces.MSBuildWorkspaceFinder.FindWorkspace(String searchDirectory, String workspacePath)
   at Microsoft.CodeAnalysis.Tools.Workspaces.MSBuildWorkspaceFinder.FindWorkspace(String searchDirectory, String workspacePath)
   at Microsoft.CodeAnalysis.Tools.FormatCommandCommon.ParseWorkspaceOptions(ParseResult parseResult, FormatOptions formatOptions)
   at Microsoft.CodeAnalysis.Tools.Commands.RootFormatCommand.FormatCommandDefaultHandler.InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken)
   at System.CommandLine.Invocation.InvocationPipeline.InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken)
Error: Process completed with exit code 1.
```

https://github.com/tSigler2/mggj/actions/runs/16556440676/job/46818533020
