### PR TITLE
Hotfix: Formatted the Windows builds to be uploaded as a .zip file and install .NET SDK in each job

### DIFF
--- a/.github/workflows/godot-ci.yml
+++ b/.github/workflows/godot-ci.yml
@@ -21,27 +21,47 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+      - name: Install .NET SDK
+        run: |
+          apt-get update
+          apt-get install -y wget
+          wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          apt-get update
+          apt-get install -y dotnet-sdk-8.0
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/export_templates/
           mkdir -v -p ~/.config/
           mv /root/.config/godot ~/.config/godot
           mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+      - name: Restore .NET dependencies
+        run: dotnet restore $PROJECT_PATH/mggj.csproj
+      - name: Build .NET project
+        run: dotnet build $PROJECT_PATH/mggj.csproj -c Release
       - name: Windows Build
         run: |
           mkdir -v -p build/windows
           EXPORT_DIR="$(readlink -f build)"
           cd $PROJECT_PATH
           godot --headless --verbose --export-release "Windows Desktop" "$EXPORT_DIR/windows/$EXPORT_NAME.exe"
+      - name: Package Windows Build
+        run: |
+          cd build/windows
+          zip -r "$EXPORT_NAME-windows.zip" ./*
+      # Debugging step to verify files
+      - name: List build directory
+        run: ls -lh build/windows
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows
-          path: build/windows
+          path: build/windows/${{ env.EXPORT_NAME }}-windows.zip
 
   export-linux:
     name: Linux Export
-    runs-on: ubuntu-22.04 # Use 22.04 with godot 4
+    runs-on: ubuntu-22.04
     container:
       image: barichello/godot-ci:4.4.1
     steps:
@@ -49,16 +69,35 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+
+      - name: Install .NET SDK
+        run: |
+          apt-get update
+          apt-get install -y wget
+          wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          apt-get update
+          apt-get install -y dotnet-sdk-8.0
+
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/export_templates/
           mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+
+      - name: Restore .NET dependencies
+        run: dotnet restore $PROJECT_PATH/mggj.csproj
+
+      - name: Build .NET project
+        run: dotnet build $PROJECT_PATH/mggj.csproj -c Release
+
       - name: Linux Build
         run: |
           mkdir -v -p build/linux
           EXPORT_DIR="$(readlink -f build)"
           cd $PROJECT_PATH
           godot --headless --verbose --export-release "Linux/X11" "$EXPORT_DIR/linux/$EXPORT_NAME.x86_64"
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -75,33 +114,54 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+
+      - name: Install .NET SDK
+        run: |
+          apt-get update
+          apt-get install -y wget
+          wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          apt-get update
+          apt-get install -y dotnet-sdk-8.0
+
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/export_templates/
           mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+
+      - name: Restore .NET dependencies
+        run: dotnet restore $PROJECT_PATH/mggj.csproj
+
+      - name: Build .NET project
+        run: dotnet build $PROJECT_PATH/mggj.csproj -c Release
+
       - name: Web Build
         run: |
           mkdir -v -p build/web
           EXPORT_DIR="$(readlink -f build)"
           cd $PROJECT_PATH
           godot --headless --verbose --export-release "Web" "$EXPORT_DIR/web/index.html"
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: web
           path: build/web
-      - name: Install rsync 📚
+
+      - name: Install rsync
         run: |
           apt-get update && apt-get install -y rsync
-      - name: Deploy to GitHub Pages 🚀
+
+      - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: build/web # The folder the action should deploy.
+          branch: gh-pages
+          folder: build/web
 
   export-mac:
     name: Mac Export
-    runs-on: ubuntu-22.04 # Use 22.04 with godot 4
+    runs-on: ubuntu-22.04
     container:
       image: barichello/godot-ci:4.4.1
     steps:
@@ -109,16 +169,35 @@ jobs:
         uses: actions/checkout@v4
         with:
           lfs: true
+
+      - name: Install .NET SDK
+        run: |
+          apt-get update
+          apt-get install -y wget
+          wget https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+          dpkg -i packages-microsoft-prod.deb
+          rm packages-microsoft-prod.deb
+          apt-get update
+          apt-get install -y dotnet-sdk-8.0
+
       - name: Setup
         run: |
           mkdir -v -p ~/.local/share/godot/export_templates/
           mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+
+      - name: Restore .NET dependencies
+        run: dotnet restore $PROJECT_PATH/mggj.csproj
+
+      - name: Build .NET project
+        run: dotnet build $PROJECT_PATH/mggj.csproj -c Release
+
       - name: Mac Build
         run: |
           mkdir -v -p build/mac
           EXPORT_DIR="$(readlink -f build)"
           cd $PROJECT_PATH
           godot --headless --verbose --export-release "macOS" "$EXPORT_DIR/mac/$EXPORT_NAME.zip"
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -135,13 +214,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-
-      # Check job statuses BEFORE moving files
+      # Windows check now looks for zip
       - name: Get Job Statuses
         id: job-status
         run: |
-          # Check Windows
-          if [ -f "artifacts/windows/$EXPORT_NAME.exe" ]; then
+          # Windows
+          if [ -f "artifacts/windows/${{ env.EXPORT_NAME }}-windows.zip" ]; then
             windows_status="✅ Success"
           else
             windows_status="❌ Failed"
@@ -178,11 +256,8 @@ jobs:
           mkdir -p release_assets
 
           # Windows
-          if [ -f "artifacts/windows/$EXPORT_NAME.exe" ]; then
-            mv "artifacts/windows/$EXPORT_NAME.exe" "release_assets/$EXPORT_NAME.exe"
-          fi
-          if [ -f "artifacts/windows/$EXPORT_NAME.pck" ]; then
-            mv "artifacts/windows/$EXPORT_NAME.pck" "release_assets/$EXPORT_NAME.pck"
+          if [ -f "artifacts/windows/${{ env.EXPORT_NAME }}-windows.zip" ]; then
+            mv "artifacts/windows/${{ env.EXPORT_NAME }}-windows.zip" "release_assets/${{ env.EXPORT_NAME }}-windows.zip"
           fi
 
           # Linux
@@ -211,8 +286,8 @@ jobs:
           mac_link=""
           web_link=""
 
-          if [ -f "release_assets/$EXPORT_NAME.exe" ]; then
-            windows_link="https://github.com/$repo/releases/download/$tag/$EXPORT_NAME.exe"
+          if [ -f "release_assets/${{ env.EXPORT_NAME }}-windows.zip" ]; then
+            windows_link="https://github.com/$repo/releases/download/$tag/${{ env.EXPORT_NAME }}-windows.zip"
           fi
 
           if [ -f "release_assets/$EXPORT_NAME.x86_64" ]; then


### PR DESCRIPTION
Updated the windows build to be posted as a .zip file and modified the workflow to install .NET SDK in each job